### PR TITLE
Change default log format

### DIFF
--- a/Sources/LoggerKit/LogFormatter.swift
+++ b/Sources/LoggerKit/LogFormatter.swift
@@ -14,7 +14,7 @@ public class DefaultLogFormatter: LogFormatterProtocol {
     func formatedTime() -> String {
         let date = Date()
         let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ssZZZZZ"
+        formatter.dateFormat = "HH:mm:ss"
         return formatter.string(from: date)
     }
 }

--- a/Tests/LoggerKitTests/LogFormatterTests.swift
+++ b/Tests/LoggerKitTests/LogFormatterTests.swift
@@ -7,7 +7,7 @@ final class DefaultLogFormatterTests: XCTestCase {
         let formatted = formatter.format(message: "some message", level: .info, context: LogContextMock())
 
         XCTAssertTrue(
-            match(target: formatted, regrexPattern: "\\A\\d\\d:\\d\\d:\\d\\d\\+\\d\\d:\\d\\d \\[INFO\\] some message\\z")
+            match(target: formatted, regrexPattern: "\\A\\d\\d:\\d\\d:\\d\\d \\[INFO\\] some message\\z")
         )
     }
 }


### PR DESCRIPTION
## Why
https://travis-ci.com/ngtk/LoggerKit/builds/75849389

```

LoggerKitTests.DefaultLogFormatterTests
  test_format, XCTAssertTrue failed - 
  /Users/travis/build/ngtk/LoggerKit/Tests/LoggerKitTests/LogFormatterTests.swift:11
  '''
        XCTAssertTrue(
            match(target: formatted, regrexPattern: "\\d\\d:\\d\\d:\\d\\d\\+\\d\\9;01md:\\d\\d\\ \\[INFO\\] some message")
        )
  '''
	 Executed 9 tests, with 1 failure (0 unexpected) in 0.026 (0.052) seconds

```

Timezone is missing. I don't know why, but I think it is not absolutely necessary.

```
❌  fatal error: debug-formatted: 15:08:14Z [INFO] some message: file /Users/travis/build/ngtk/LoggerKit/Tests/LoggerKitTests/LogFormatterTests.swift, line 10
```

https://travis-ci.com/ngtk/LoggerKit/builds/75850252

## What
Remove timezone and fix the test.