### PR TITLE
Change message parameter variadic

### DIFF
--- a/Sources/LoggerKit/Logger.swift
+++ b/Sources/LoggerKit/Logger.swift
@@ -6,7 +6,7 @@ public protocol LoggerProtocol {
 
 extension LoggerProtocol {
     public func debug(
-        _ message: Any,
+        _ message: Any...,
         function: String = #function,
         file: String = #file,
         line: Int = #line
@@ -16,7 +16,7 @@ extension LoggerProtocol {
     }
 
     public func verbose(
-        _ message: Any,
+        _ message: Any...,
         function: String = #function,
         file: String = #file,
         line: Int = #line
@@ -26,7 +26,7 @@ extension LoggerProtocol {
     }
 
     public func info(
-        _ message: Any,
+        _ message: Any...,
         function: String = #function,
         file: String = #file,
         line: Int = #line
@@ -36,7 +36,7 @@ extension LoggerProtocol {
     }
 
     public func warning(
-        _ message: Any,
+        _ message: Any...,
         function: String = #function,
         file: String = #file,
         line: Int = #line
@@ -46,7 +46,7 @@ extension LoggerProtocol {
     }
 
     public func error(
-        _ message: Any,
+        _ message: Any...,
         function: String = #function,
         file: String = #file,
         line: Int = #line

--- a/Tests/LoggerKitTests/LoggerTests.swift
+++ b/Tests/LoggerKitTests/LoggerTests.swift
@@ -44,37 +44,43 @@ final class LoggerProtocolTests: XCTestCase {
 
     func test_debug() {
         let someLogger = SomeLogger(sendClosure: { level, message, _ in
-            XCTAssertTrue(level == .debug && "\(message)" == "message for debug")
+            XCTAssertTrue(level == .debug && String(message: message) == "message for debug")
         })
         someLogger.debug("message for debug")
     }
     
     func test_verbose() {
         let someLogger = SomeLogger(sendClosure: { level, message, _ in
-            XCTAssertTrue(level == .verbose && "\(message)" == "message for verbose")
+            XCTAssertTrue(level == .verbose && String(message: message) == "message for verbose")
         })
         someLogger.verbose("message for verbose")
     }
 
     func test_info() {
         let someLogger = SomeLogger(sendClosure: { level, message, _ in
-            XCTAssertTrue(level == .info && "\(message)" == "message for info")
+            XCTAssertTrue(level == .info && String(message: message) == "message for info")
         })
-        someLogger.info("message for info")
+        someLogger.info("message for info", "")
     }
 
     func test_warning() {
         let someLogger = SomeLogger(sendClosure: { level, message, _ in
-            XCTAssertTrue(level == .warning && "\(message)" == "message for warning")
+            XCTAssertTrue(level == .warning && String(message: message) == "message for warning")
         })
         someLogger.warning("message for warning")
     }
 
     func test_error() {
         let someLogger = SomeLogger(sendClosure: { level, message, _ in
-            XCTAssertTrue(level == .error && "\(message)" == "message for error")
+            XCTAssertTrue(level == .error && String(message: message) == "message for error")
         })
         someLogger.error("message for error")
     }
+}
 
+private extension String {
+    init?(message: Any) {
+        guard let joined = (message as? Array<String>)?.joined() else { return nil }
+        self.init(joined)
+    }
 }


### PR DESCRIPTION
## Why
We expect message parameter is variadic like standard lib `print` func, but it's not.


## What
Change `message` parameter variadic.



```diff
- logger.debug("variable: \(variable)")
+ logger.debug("variable:", variable)
```